### PR TITLE
fix: troubleshoot storybook build in Nx with Vite

### DIFF
--- a/libs/design-system/README.md
+++ b/libs/design-system/README.md
@@ -14,3 +14,19 @@ yarn nx g @nx/react:storybook-configuration
 ## Running unit tests
 
 Run `nx test design-system` to execute the unit tests via [Vitest](https://vitest.dev/).
+
+## Troubleshooting
+
+```bash
+Failed to resolve entry for package "crypto". The package may have incorrect main/module/exports specified in its package.json. [plugin vite:dep-pre-bundle]
+```
+
+**Resolution**
+
+We shouldn't use crypto package from npm because it's deprecated (https://www.npmjs.com/package/crypto). Vite uses build-in crypto module from Node.js.
+
+See https://github.com/vitejs/vite/issues/12602.
+
+```bash
+yarn remove crypto
+```

--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     "@xata.io/cli": "^0.16.7",
     "@xata.io/client": "^0.30.0",
     "clsx": "^2.1.1",
-    "crypto": "^1.0.1",
     "dayjs": "^1.11.13",
     "dotenv": "^16.4.5",
     "drizzle-orm": "^0.33.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9003,11 +9003,6 @@ crypto-random-string@^2.0.0:
   resolved "https://registry.yarnpkg.com/crypto-random-string/-/crypto-random-string-2.0.0.tgz#ef2a7a966ec11083388369baa02ebead229b30d5"
   integrity sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==
 
-crypto@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/crypto/-/crypto-1.0.1.tgz#2af1b7cad8175d24c8a1b0778255794a21803037"
-  integrity sha512-VxBKmeNcqQdiUQUW2Tzq0t377b54N2bMtXO/qiLa+6eRRmmC4qT3D4OnTGoT/U6O9aklQ/jTwbOtRMTTY8G0Ig==
-
 css-declaration-sorter@^7.2.0:
   version "7.2.0"
   resolved "https://registry.yarnpkg.com/css-declaration-sorter/-/css-declaration-sorter-7.2.0.tgz#6dec1c9523bc4a643e088aab8f09e67a54961024"


### PR DESCRIPTION
## Error

```bash
Failed to resolve entry for package "crypto". 
The package may have incorrect main/module/exports specified in its package.json. 
[plugin vite:dep-pre-bundle]
```

## Why?

`crypto` module was introduced in this commit... https://github.com/takahirohonda/language-masters/commit/6273d6eb8cabdfd5f20f952c70e31f27423a6fcb

I might have been introduced when I was auto configuring drizzle...

## Resolution

We shouldn't use crypto package from npm because it's deprecated (https://www.npmjs.com/package/crypto). Vite uses build-in crypto module from Node.js.

See https://github.com/vitejs/vite/issues/12602.

```bash
yarn remove crypto
```